### PR TITLE
Updated broken URLs on examples directory to working URLs

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -14,13 +14,13 @@
       <div class="container">
         <h1 class="title">reLiftHTML</h1>
         <p class="description">A simple view library</p>
-        <a class="button" target="_blank" href="https://mardix.github.com/relift" title="Getting Started"
+        <a class="button" target="_blank" href="https://relift-html.js.org/guide/" title="Getting Started"
           >Documentation</a
         >
         <a
           class="button button-outlined"
           target="_blank"
-          href="https://mardix.github.com/relift"
+          href="https://relift-html.js.org/demo/"
           title="Getting Started"
           >Demo</a
         >


### PR DESCRIPTION
The URLs in examples/index.html (Documentation and Demo) are broken. Added a working URLs in their place.