### PR TITLE
Fix #20 miss typo "somAClass" into "someClassA"

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -168,7 +168,7 @@ This demostrates how we can interact with an element externally with javascript 
 ```html
 
 <style>
-  .somAClass {
+  .someClassA {
     color: blue
   }
   .myClassB {


### PR DESCRIPTION
I think that it should be "someClassA" css class name in example5.