### PR TITLE
css directive bug when use with normal css class

### DIFF
--- a/src/directives.js
+++ b/src/directives.js
@@ -100,7 +100,7 @@ function _class(el, value, directive) {
     .map(v => v.split(':', 2).map(e => e.trim()))
     .map(v => `\${${v[1]} ? '${v[0]}': ''}`)
     .join(' ');
-  const classList = el.getAttribute('class') || '' + ` ${klass}`;
+  const classList = (el.getAttribute('class') || '') + ` ${klass}`;
   el.setAttribute('class', classList);
   remove(el, directive);
 }


### PR DESCRIPTION
I found some bugs when use css directive with normal css class name.
**How to reproduce:**
i use parcel as bundler.

```
/* html */
  <style>
    body, html {
      font-family: 'Cascadia Code';
      margin: 0;
      padding: 0;
    }
    .box {
      padding: 10px;
      color: #fff;
      background-color: #88a343;
    }
    .redBG {
      background-color: red
    }
    .blueBG {
      background-color: blue;
    }
  </style>
</head>
<body>
  <div id="myContainer">
    <div>Counting {this.count}</div>
    <div :class="blueBG: this.count > 20" class="box">
      Will have .blueBG and .box if count is {this.count}.
    </div>
  </div>
  <script src="main.js"></script>
</body>
</html>

/* main.js */
import Litedom from 'litedom/dist/litedom.es'
Litedom({
  el: '#myContainer',
  // reactive data
  data: {
    count: 60,
  },
});
```
<img width="1529" alt="Screenshot 2562-10-03 at 00 09 45" src="https://user-images.githubusercontent.com/1311673/66065670-27e71980-e572-11e9-90f7-975172918cad.png">

It should be ...

![xxx](https://user-images.githubusercontent.com/1311673/66065823-74325980-e572-11e9-9c8f-63b7eecd26ee.jpg)



